### PR TITLE
feat: add connect.ataca.io links

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                         </svg>
                     </div>
                     <div>
-                        <h3 class="text-xl md:text-2xl font-bold">connect</h3>
+                        <h3 class="text-xl md:text-2xl font-bold"><a href="https://connect.ataca.io" target="_blank" class="hover:text-indigo-400 transition">connect</a></h3>
                         <p class="text-gray-400 text-sm">Omnichannel Messaging Platform</p>
                     </div>
                 </div>
@@ -195,6 +195,15 @@
                             </li>
                         </ul>
                     </div>
+                </div>
+
+                <div class="mt-6 md:mt-8">
+                    <a href="https://connect.ataca.io" target="_blank" class="inline-flex items-center px-5 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium rounded-lg transition">
+                        Learn more
+                        <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                        </svg>
+                    </a>
                 </div>
             </div>
         </div>
@@ -305,6 +314,7 @@
             <div>
                 <h4 class="font-semibold mb-4">Services</h4>
                 <ul class="space-y-2 text-sm text-gray-400">
+                    <li><a href="https://connect.ataca.io" target="_blank" class="hover:text-white transition">Connect</a></li>
                     <li><a href="#services" class="hover:text-white transition">Infrastructure</a></li>
                     <li><a href="#services" class="hover:text-white transition">DevOps</a></li>
                     <li><a href="#services" class="hover:text-white transition">Security</a></li>


### PR DESCRIPTION
## Summary
- Link Connect service card title to connect.ataca.io
- Add "Learn more" CTA button to Connect card
- Add Connect link to footer Services list

## Test plan
- [ ] Verify links open connect.ataca.io in new tab once DNS is configured
- [ ] Check card layout and button styling on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)