### PR TITLE
feat: add Rail transactional email service section

### DIFF
--- a/docs/superpowers/specs/2026-03-22-rail-service-section-design.md
+++ b/docs/superpowers/specs/2026-03-22-rail-service-section-design.md
@@ -1,0 +1,65 @@
+# Rail Service Section — Design Spec
+
+## Overview
+
+Add a featured service card for **Rail** (transactional email delivery) to the Ataca landing page, matching the existing Connect card's structure and prominence. Also add a footer link.
+
+## Context
+
+- **Rail** is a transactional email delivery service at `rail.ataca.io`
+- It offers SMTP relay and HTTP API integration, both secured with mTLS (client certificates)
+- The Ataca landing page (`index.html`) is a single-page static site using Tailwind CSS via CDN
+- Connect currently has a full-width featured card; other services sit in a 3-column grid below it
+- GitHub Issue: #2
+
+## Changes
+
+Two modifications to `index.html`:
+
+### 1. Rail Featured Card
+
+**Placement:** Immediately after the Connect card, before the 3-column services grid.
+
+**Structure** (mirrors Connect exactly):
+
+- **Wrapper:** `bg-gray-800/50 rounded-2xl p-6 md:p-8 border border-gray-700` inside a `mb-12 md:mb-16` container
+- **Header row:**
+  - Icon: Envelope SVG inside `w-10 md:w-12 h-10 md:h-12 bg-emerald-600 rounded-lg`
+  - Title: `rail` (lowercase) as an `<a>` linking to `https://rail.ataca.io` with `hover:text-emerald-400 transition`
+  - Subtitle: "Transactional Email Delivery" in `text-gray-400 text-sm`
+- **Description paragraph:** "Simple transactional email delivery for your services. Send notifications, alerts, and receipts — Rail handles the infrastructure with mTLS-secured delivery over SMTP and HTTP API."
+- **Two-column grid** (`grid md:grid-cols-2 gap-6 md:gap-8`):
+  - **Left — Integration Methods** (header in `text-emerald-400`):
+    - SMTP Relay (emerald bullet)
+    - HTTP API (emerald bullet)
+  - **Right — Features** (header in `text-emerald-400`):
+    - mTLS authentication (emerald bullet)
+    - Transactional delivery (emerald bullet)
+    - Live status dashboard (emerald bullet)
+- **CTA button:** "Learn more" linking to `https://rail.ataca.io`, styled `bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg`
+
+**Accent color:** Emerald (`bg-emerald-600`, `text-emerald-400`, `hover:bg-emerald-700`) — distinguishes Rail from Connect's indigo while echoing the "Operational" green from rail.ataca.io.
+
+### 2. Footer Link
+
+Add "Rail" to the Services list in the footer, immediately after "Connect":
+
+```html
+<li><a href="https://rail.ataca.io" target="_blank" class="hover:text-white transition">Rail</a></li>
+```
+
+## Out of Scope
+
+- No version number (v0.4) on the marketing site
+- No live status indicator or `/stats` integration
+- No code snippets or language-specific SDK mentions
+- No new pages or routes — changes are confined to `index.html`
+
+## Acceptance Criteria
+
+1. Rail card renders correctly on mobile and desktop
+2. Card structure matches Connect's pattern (icon, title link, subtitle, description, two-column grid, CTA)
+3. Emerald accent color is consistent across icon, section headers, bullets, and CTA
+4. Footer lists Rail after Connect
+5. All links to `rail.ataca.io` open in new tab (`target="_blank"`)
+6. No visual regression to existing sections

--- a/index.html
+++ b/index.html
@@ -213,13 +213,13 @@
             <div class="bg-gray-800/50 rounded-2xl p-6 md:p-8 border border-gray-700">
                 <div class="flex items-center mb-6">
                     <div class="w-10 md:w-12 h-10 md:h-12 bg-emerald-600 rounded-lg flex items-center justify-center mr-3 md:mr-4 flex-shrink-0">
-                        <svg class="w-5 md:w-6 h-5 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="2" y="4" width="20" height="16" rx="2"/>
-                            <path d="M22 7l-10 7L2 7"/>
+                        <svg class="w-5 md:w-6 h-5 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <rect x="2" y="4" width="20" height="16" rx="2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M22 7l-10 7L2 7"/>
                         </svg>
                     </div>
                     <div>
-                        <h3 class="text-xl md:text-2xl font-bold"><a href="https://rail.ataca.io" target="_blank" class="hover:text-emerald-400 transition">rail</a></h3>
+                        <h3 class="text-xl md:text-2xl font-bold"><a href="https://rail.ataca.io" target="_blank" rel="noopener noreferrer" class="hover:text-emerald-400 transition">rail</a></h3>
                         <p class="text-gray-400 text-sm">Transactional Email Delivery</p>
                     </div>
                 </div>
@@ -258,7 +258,7 @@
                 </div>
 
                 <div class="mt-6 md:mt-8">
-                    <a href="https://rail.ataca.io" target="_blank" class="inline-flex items-center px-5 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition">
+                    <a href="https://rail.ataca.io" target="_blank" rel="noopener noreferrer" class="inline-flex items-center px-5 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition">
                         Learn more
                         <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
@@ -375,7 +375,7 @@
                 <h4 class="font-semibold mb-4">Services</h4>
                 <ul class="space-y-2 text-sm text-gray-400">
                     <li><a href="https://connect.ataca.io" target="_blank" class="hover:text-white transition">Connect</a></li>
-                    <li><a href="https://rail.ataca.io" target="_blank" class="hover:text-white transition">Rail</a></li>
+                    <li><a href="https://rail.ataca.io" target="_blank" rel="noopener noreferrer" class="hover:text-white transition">Rail</a></li>
                     <li><a href="#services" class="hover:text-white transition">Infrastructure</a></li>
                     <li><a href="#services" class="hover:text-white transition">DevOps</a></li>
                     <li><a href="#services" class="hover:text-white transition">Security</a></li>

--- a/index.html
+++ b/index.html
@@ -375,6 +375,7 @@
                 <h4 class="font-semibold mb-4">Services</h4>
                 <ul class="space-y-2 text-sm text-gray-400">
                     <li><a href="https://connect.ataca.io" target="_blank" class="hover:text-white transition">Connect</a></li>
+                    <li><a href="https://rail.ataca.io" target="_blank" class="hover:text-white transition">Rail</a></li>
                     <li><a href="#services" class="hover:text-white transition">Infrastructure</a></li>
                     <li><a href="#services" class="hover:text-white transition">DevOps</a></li>
                     <li><a href="#services" class="hover:text-white transition">Security</a></li>

--- a/index.html
+++ b/index.html
@@ -208,6 +208,66 @@
             </div>
         </div>
 
+        <!-- rail -->
+        <div class="mb-12 md:mb-16">
+            <div class="bg-gray-800/50 rounded-2xl p-6 md:p-8 border border-gray-700">
+                <div class="flex items-center mb-6">
+                    <div class="w-10 md:w-12 h-10 md:h-12 bg-emerald-600 rounded-lg flex items-center justify-center mr-3 md:mr-4 flex-shrink-0">
+                        <svg class="w-5 md:w-6 h-5 md:h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="2" y="4" width="20" height="16" rx="2"/>
+                            <path d="M22 7l-10 7L2 7"/>
+                        </svg>
+                    </div>
+                    <div>
+                        <h3 class="text-xl md:text-2xl font-bold"><a href="https://rail.ataca.io" target="_blank" class="hover:text-emerald-400 transition">rail</a></h3>
+                        <p class="text-gray-400 text-sm">Transactional Email Delivery</p>
+                    </div>
+                </div>
+
+                <p class="text-gray-300 mb-6 md:mb-8">
+                    Simple transactional email delivery for your services.
+                    Send notifications, alerts, and receipts — Rail handles the infrastructure with mTLS-secured delivery over SMTP and HTTP API.
+                </p>
+
+                <div class="grid md:grid-cols-2 gap-6 md:gap-8">
+                    <div>
+                        <h4 class="font-semibold mb-3 md:mb-4 text-emerald-400">Integration Methods</h4>
+                        <ul class="space-y-2 text-gray-300">
+                            <li class="flex items-center">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full mr-3 flex-shrink-0"></span>SMTP Relay
+                            </li>
+                            <li class="flex items-center">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full mr-3 flex-shrink-0"></span>HTTP API
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h4 class="font-semibold mb-3 md:mb-4 text-emerald-400">Features</h4>
+                        <ul class="space-y-2 text-gray-300">
+                            <li class="flex items-center">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full mr-3 flex-shrink-0"></span>mTLS authentication
+                            </li>
+                            <li class="flex items-center">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full mr-3 flex-shrink-0"></span>Transactional delivery
+                            </li>
+                            <li class="flex items-center">
+                                <span class="w-2 h-2 bg-emerald-500 rounded-full mr-3 flex-shrink-0"></span>Live status dashboard
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="mt-6 md:mt-8">
+                    <a href="https://rail.ataca.io" target="_blank" class="inline-flex items-center px-5 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-lg transition">
+                        Learn more
+                        <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <!-- Other Services Grid -->
         <div class="grid md:grid-cols-3 gap-4 md:gap-6">
             <div class="bg-gray-800/50 rounded-xl p-5 md:p-6 border border-gray-700">


### PR DESCRIPTION
## Summary
- Add featured Rail service card to landing page, mirroring Connect card pattern with emerald accent color
- Card includes envelope icon, description, two-column grid (Integration Methods + Features), and "Learn more" CTA linking to rail.ataca.io
- Add Rail link to footer Services list after Connect
- Add `rel="noopener noreferrer"` to all external Rail links

Closes #2

## Test Plan
- [x] Desktop rendering verified (1280px) via Playwright
- [x] Mobile rendering verified (375px) via Playwright
- [x] All three Rail links (title, CTA, footer) open rail.ataca.io in new tab
- [x] No visual regression to existing sections
- [x] SVG attributes follow Connect card pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)